### PR TITLE
Feature multiple sender

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  # auto merge from y1ndan/genshin-impact-helper, default: false
+  # auto merge from PomeloWang/genshin-impact-helper, default: false
   ALLOW_MERGE: 'false'
   RUN_ENV: 'prod'
   TZ: 'Asia/Shanghai'
@@ -28,7 +28,7 @@ jobs:
         run: |
           git config --global user.name  github-actions
           git config --global user.email github-actions@github.com
-          git remote add upstream https://github.com/y1ndan/genshin-impact-helper
+          git remote add upstream https://github.com/PomeloWang/genshin-impact-helper
           git pull upstream master --allow-unrelated-histories
           git push origin master
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  # auto merge from PomeloWang/genshin-impact-helper, default: false
+  # auto merge from y1ndan/genshin-impact-helper, default: false
   ALLOW_MERGE: 'false'
   RUN_ENV: 'prod'
   TZ: 'Asia/Shanghai'
@@ -28,7 +28,7 @@ jobs:
         run: |
           git config --global user.name  github-actions
           git config --global user.email github-actions@github.com
-          git remote add upstream https://github.com/PomeloWang/genshin-impact-helper
+          git remote add upstream https://github.com/y1ndan/genshin-impact-helper
           git pull upstream master --allow-unrelated-histories
           git push origin master
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,35 @@ Error: Process completed with exit code 255.
 
 </details>
 
+## 🔔订阅
+
+#### 若开启订阅推送，无论成功与否，都会收到微信通知。
+
+- 使用 GitHub 登录 [sc.ftqq.com](http://sc.ftqq.com/?c=github&a=login) 创建账号
+- 点击「[发送消息](http://sc.ftqq.com/?c=code)」，获取`SCKEY`
+- 点击「[微信推送](http://sc.ftqq.com/?c=wechat&a=bind)」，完成微信绑定
+- 建立名为`SCKEY`的 secret，并添加获取的 SCKEY 值，即可开启订阅推送
+
+#### 如果需要额外的通知渠道可以自己根据一下规则实现
+- 认证信息使用 `secret` 存储 (推荐)
+- 所有通知渠道放到`notify.py`内实现, 继承自`Sender` 类
+
+通知调用格式, `message` 为原始信息包含以下`key`
+```python
+# today             当天时间
+# region_name       区服
+# uid               UID
+# award_name        礼品
+# award_cnt         礼品数量
+# total_sign_day    签到天数
+# status            上层API返回的 messgae 字段或自定义的消息
+# end               格式化用
+
+# 在 notify.py 中按照以下签名实现自己的通知渠道即可
+def send(self, title, status, message):
+     """please implemente in subclass"""
+```
+
 ## 🔨开发
 
 如果需要重构或增加额外功能参考以下数据
@@ -189,15 +218,6 @@ infos = [
 ]
 
 ```
-## 🔔订阅
-
-若开启订阅推送，无论成功与否，都会收到微信通知。
-
-- 使用 GitHub 登录 [sc.ftqq.com](http://sc.ftqq.com/?c=github&a=login) 创建账号
-- 点击「[发送消息](http://sc.ftqq.com/?c=code)」，获取`SCKEY`
-- 点击「[微信推送](http://sc.ftqq.com/?c=wechat&a=bind)」，完成微信绑定
-- 建立名为`SCKEY`的 secret，并添加获取的 SCKEY 值，即可开启订阅推送
-
 ## ❗️协议
 
 使用 Genshin Impact Helper 即表明，您知情并同意：

--- a/notify.py
+++ b/notify.py
@@ -1,0 +1,68 @@
+import abc
+import json
+import os
+import sys
+
+import requests
+from requests.exceptions import *
+
+from settings import *
+
+__all__ = ['Notify']
+
+
+class Sender(abc.ABC):
+    @staticmethod
+    def to_python(json_str: str):
+        return json.loads(json_str)
+
+    @staticmethod
+    def to_json(obj):
+        return json.dumps(obj, indent=4, ensure_ascii=False)
+
+    @abc.abstractmethod
+    def send(self, title, status, message):
+        """please implemente in subclass"""
+
+
+class ServerJiang(Sender):
+    def send(self, title, status, message):
+        message = CONFIG.MESSGAE_TEMPLATE.format(**message)
+
+        secret = os.environ.get('SCKEY', '')
+        if isinstance(message, list) or isinstance(message, dict):
+            message = self.to_json(message)
+        log.info('签到{}: {}'.format(status, message))
+
+        if secret.startswith('SC'):
+            log.info('准备推送通知...')
+            url = 'https://sc.ftqq.com/{}.send'.format(secret)
+            data = {'text': '原神签到小助手 签到{}'.format(status), 'desp': message}
+            try:
+                response = self.to_python(requests.Session().post(url, data=data).text)
+            except Exception as e:
+                log.error(e)
+                raise HTTPError
+            else:
+                errmsg = response['errmsg']
+                if errmsg == 'success':
+                    log.info('推送成功')
+                else:
+                    log.error('{}: {}'.format('推送失败', response))
+        else:
+            log.info('未配置SCKEY,正在跳过推送')
+        return log.info('任务结束')
+
+
+class Notify(object):
+    default_notify_class = "ServerJiang"
+
+    def __new__(cls, *args, **kwargs):
+        notify_class = kwargs.get('notify_class', cls.default_notify_class)
+
+        this_mod = sys.modules[__name__]
+        notify_class = getattr(this_mod, notify_class, None)
+
+        if notify_class is None:
+            raise ModuleNotFoundError("not found {}.{}".format(this_mod, notify_class))
+        return notify_class()

--- a/settings.py
+++ b/settings.py
@@ -26,6 +26,7 @@ class _Config:
     SIGN_URL = 'https://api-takumi.mihoyo.com/event/bbs_sign_reward/sign'
     USER_AGENT = 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) ' \
                  'miHoYoBBS/{}'.format(APP_VERSION)
+    NOTIFY_CLASS = os.environ.get('NotifyClass', 'ServerJiang')
 
 
 class ProductionConfig(_Config):


### PR DESCRIPTION
#### 如果需要额外的通知渠道可以自己根据一下规则实现
- 认证信息使用 `secret` 存储 (推荐)
- 所有通知渠道放到`notify.py`内实现, 继承自`Sender` 类

通知调用格式, `message` 为原始信息包含以下`key`
```python
# today             当天时间
# region_name       区服
# uid               UID
# award_name        礼品
# award_cnt         礼品数量
# total_sign_day    签到天数
# status            上层API返回的 messgae 字段或自定义的消息
# end               格式化用

# 在 notify.py 中按照以下签名实现自己的通知渠道即可
def send(self, title, status, message):
     """please implemente in subclass"""
```